### PR TITLE
Add autorestart mechanism after an update

### DIFF
--- a/s3update.go
+++ b/s3update.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"runtime"
 	"strconv"
 	"strings"
@@ -139,8 +140,21 @@ func runAutoUpdate(u Updater) error {
 		// Removing backup
 		os.Remove(destBackup)
 
-		fmt.Printf("s3update: updated with success to version %d\n", remoteVersion)
-		os.Exit(1)
+		fmt.Printf("s3update: updated with success to version %d\nRestarting application\n", remoteVersion)
+
+		// The update completed, we can now restart the application without requiring any user action.
+		var args []string
+		if len(os.Args) > 1 {
+			args = os.Args[1:]
+		}
+		cmd := exec.Command(os.Args[0], args...)
+		cmd.Stdin = os.Stdin
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+		os.Exit(0)
 	}
 
 	return nil


### PR DESCRIPTION
With the current implementation each update requiers the user to re-run the command.

This PR solves this by restarting the command automatically, so the user doesn't need to do anything except waiting for the process to complete 🤘  