### PR TITLE
Use os.Executable in favor of osext.Executable

### DIFF
--- a/s3update.go
+++ b/s3update.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/kardianos/osext"
 	"github.com/mitchellh/ioprogress"
 )
 
@@ -130,7 +129,7 @@ func runAutoUpdate(u Updater) error {
 		if err != nil {
 			return err
 		}
-		dest, err := osext.Executable()
+		dest, err := os.Executable()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Since Go 1.8 os.Executable is part of the stdlib, so osext can be dropped
from the dependencies.

That change is not tested, because a test requires to create a s3 bucket
and a fake binary. That said I'm confident because a recent change in
osext invokes os.Executable if the library is compiled under Go 1.8.